### PR TITLE
Added web3 version 7 support and loosened other dependencies

### DIFF
--- a/avantis_trader_sdk/rpc/asset_parameters.py
+++ b/avantis_trader_sdk/rpc/asset_parameters.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from .rpc_helpers import map_output_to_pairs
 from ..types import (
     OpenInterest,
@@ -8,8 +9,8 @@ from ..types import (
     Spread,
     Depth,
 )
+from ..utils import encode_abi
 from typing import Optional
-
 
 class AssetParametersRPC:
     """
@@ -39,7 +40,7 @@ class AssetParametersRPC:
         pairs_info = await self.client.pairs_cache.get_pairs_info()
         calls = []
         for pair_index in range(len(pairs_info)):
-            call_data = PairStorage.encodeABI(fn_name="pairMaxOI", args=[pair_index])
+            call_data = encode_abi(PairStorage, "pairMaxOI", args=[pair_index])
             calls.append((PairStorage.address, call_data))
 
         response = await Multicall.functions.aggregate(calls).call()
@@ -88,7 +89,7 @@ class AssetParametersRPC:
         pairs_info = await self.client.pairs_cache.get_pairs_info()
         calls = []
         for pair_index in range(len(pairs_info)):
-            call_data = TradingStorage.encodeABI(fn_name="pairOI", args=[pair_index])
+            call_data = encode_abi(TradingStorage, "pairOI", args=[pair_index])
             calls.append((TradingStorage.address, call_data))
 
         oi_limits_task = self.get_oi_limits()
@@ -159,15 +160,17 @@ class AssetParametersRPC:
                     [
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getPriceImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getPriceImpactSpread",
                                 args=[pair_index, True, position_size, False],
-                            ),
+                            )
                         ),
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getPriceImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getPriceImpactSpread",
                                 args=[pair_index, False, position_size, False],
                             ),
                         ),
@@ -187,15 +190,17 @@ class AssetParametersRPC:
                         [
                             (
                                 PairInfos.address,
-                                PairInfos.encodeABI(
-                                    fn_name="getPriceImpactSpread",
+                                encode_abi(
+                                    PairInfos,
+                                    "getPriceImpactSpread",
                                     args=[pair_index, True, position_size, False],
                                 ),
                             ),
                             (
                                 PairInfos.address,
-                                PairInfos.encodeABI(
-                                    fn_name="getPriceImpactSpread",
+                                encode_abi(
+                                    PairInfos,
+                                    "getPriceImpactSpread",
                                     args=[pair_index, False, position_size, False],
                                 ),
                             ),
@@ -205,8 +210,9 @@ class AssetParametersRPC:
                     calls.append(
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getPriceImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getPriceImpactSpread",
                                 args=[pair_index, is_long, position_size, False],
                             ),
                         )
@@ -293,15 +299,17 @@ class AssetParametersRPC:
                     [
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getSkewImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getSkewImpactSpread",
                                 args=[pair_index, True, position_size, False],
                             ),
                         ),
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getSkewImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getSkewImpactSpread",
                                 args=[pair_index, False, position_size, False],
                             ),
                         ),
@@ -320,15 +328,17 @@ class AssetParametersRPC:
                         [
                             (
                                 PairInfos.address,
-                                PairInfos.encodeABI(
-                                    fn_name="getSkewImpactSpread",
+                                encode_abi(
+                                    PairInfos,
+                                    "getSkewImpactSpread",
                                     args=[pair_index, True, position_size, False],
                                 ),
                             ),
                             (
                                 PairInfos.address,
-                                PairInfos.encodeABI(
-                                    fn_name="getSkewImpactSpread",
+                                encode_abi(
+                                    PairInfos,
+                                    "getSkewImpactSpread",
                                     args=[pair_index, False, position_size, False],
                                 ),
                             ),
@@ -338,8 +348,9 @@ class AssetParametersRPC:
                     calls.append(
                         (
                             PairInfos.address,
-                            PairInfos.encodeABI(
-                                fn_name="getSkewImpactSpread",
+                            encode_abi(
+                                PairInfos,
+                                "getSkewImpactSpread",
                                 args=[pair_index, is_long, position_size, False],
                             ),
                         )
@@ -421,15 +432,17 @@ class AssetParametersRPC:
                 [
                     (
                         PairInfos.address,
-                        PairInfos.encodeABI(
-                            fn_name="getTradePriceImpact",
+                        encode_abi(
+                            PairInfos,
+                            "getTradePriceImpact",
                             args=[open_price, pair_index, True, position_size, False],
                         ),
                     ),
                     (
                         PairInfos.address,
-                        PairInfos.encodeABI(
-                            fn_name="getTradePriceImpact",
+                        encode_abi(
+                            PairInfos,
+                            "getTradePriceImpact",
                             args=[open_price, pair_index, False, position_size, False],
                         ),
                     ),
@@ -472,15 +485,17 @@ class AssetParametersRPC:
                 [
                     (
                         PairInfos.address,
-                        PairInfos.encodeABI(
-                            fn_name="getOnePercentDepthAbove",
+                        encode_abi(
+                            PairInfos,
+                            "getOnePercentDepthAbove",
                             args=[pair_index],
                         ),
                     ),
                     (
                         PairInfos.address,
-                        PairInfos.encodeABI(
-                            fn_name="getOnePercentDepthBelow",
+                        encode_abi(
+                            PairInfos,
+                            "getOnePercentDepthBelow",
                             args=[pair_index],
                         ),
                     ),

--- a/avantis_trader_sdk/rpc/category_parameters.py
+++ b/avantis_trader_sdk/rpc/category_parameters.py
@@ -1,5 +1,6 @@
 import asyncio
 from ..types import OpenInterest, OpenInterestLimits, Utilization, Skew
+from ..utils import encode_abi
 
 
 class CategoryParametersRPC:
@@ -39,7 +40,7 @@ class CategoryParametersRPC:
 
         calls = []
         for pair_index in pair_indexes:
-            call_data = PairStorage.encodeABI(fn_name="groupMaxOI", args=[pair_index])
+            call_data = encode_abi(PairStorage, "groupMaxOI", args=[pair_index])
             calls.append((PairStorage.address, call_data))
 
         response = await Multicall.functions.aggregate(calls).call()
@@ -66,10 +67,10 @@ class CategoryParametersRPC:
         long_calls = []
         short_calls = []
         for group_index in group_indexes:
-            call_data = PairStorage.encodeABI(fn_name="groupOIs", args=[group_index, 0])
+            call_data = encode_abi(PairStorage, "groupOIs", args=[group_index, 0])
             long_calls.append((PairStorage.address, call_data))
 
-            call_data = PairStorage.encodeABI(fn_name="groupOIs", args=[group_index, 1])
+            call_data = encode_abi(PairStorage, "groupOIs", args=[group_index, 1])
             short_calls.append((PairStorage.address, call_data))
 
         long_task = Multicall.functions.aggregate(long_calls).call()
@@ -149,7 +150,7 @@ class CategoryParametersRPC:
 
     #     calls = []
     #     for pair_index in pair_indexes:
-    #         call_data = PairStorage.encodeABI(fn_name="groupOI", args=[pair_index])
+    #         call_data = encode_abi(PairStorage, "groupOI", args=[pair_index])
     #         calls.append((PairStorage.address, call_data))
 
     #     oi_limits_task = self.get_oi_limits()

--- a/avantis_trader_sdk/rpc/fee_parameters.py
+++ b/avantis_trader_sdk/rpc/fee_parameters.py
@@ -1,6 +1,7 @@
 import asyncio
 from .rpc_helpers import map_output_to_pairs
 from ..types import MarginFee, PairSpread, Fee, TradeInput
+from ..utils import encode_abi
 from typing import Optional
 
 
@@ -58,7 +59,7 @@ class FeeParametersRPC:
         pairs_info = await self.client.pairs_cache.get_pairs_info()
         calls = []
         for pair_index in range(len(pairs_info)):
-            call_data = PairStorage.encodeABI(fn_name="pairSpreadP", args=[pair_index])
+            call_data = encode_abi(PairStorage, "pairSpreadP", args=[pair_index])
             calls.append((PairStorage.address, call_data))
 
         response = await Multicall.functions.aggregate(calls).call()
@@ -108,15 +109,17 @@ class FeeParametersRPC:
                     [
                         (
                             PriceAggregator.address,
-                            PriceAggregator.encodeABI(
-                                fn_name="openFeeP",
+                            encode_abi(
+                                PriceAggregator,
+                                "openFeeP",
                                 args=[pair_index, position_size, True],
                             ),
                         ),
                         (
                             PriceAggregator.address,
-                            PriceAggregator.encodeABI(
-                                fn_name="openFeeP",
+                            encode_abi(
+                                PriceAggregator,
+                                "openFeeP",
                                 args=[pair_index, position_size, False],
                             ),
                         ),
@@ -135,15 +138,17 @@ class FeeParametersRPC:
                         [
                             (
                                 PriceAggregator.address,
-                                PriceAggregator.encodeABI(
-                                    fn_name="openFeeP",
+                                encode_abi(
+                                    PriceAggregator,
+                                    "openFeeP",
                                     args=[pair_index, position_size, True],
                                 ),
                             ),
                             (
                                 PriceAggregator.address,
-                                PriceAggregator.encodeABI(
-                                    fn_name="openFeeP",
+                                encode_abi(
+                                    PriceAggregator,
+                                    "openFeeP",
                                     args=[pair_index, position_size, False],
                                 ),
                             ),
@@ -153,8 +158,9 @@ class FeeParametersRPC:
                     calls.append(
                         (
                             PriceAggregator.address,
-                            PriceAggregator.encodeABI(
-                                fn_name="openFeeP",
+                            encode_abi(
+                                PriceAggregator,
+                                "openFeeP",
                                 args=[pair_index, position_size, is_long],
                             ),
                         )

--- a/avantis_trader_sdk/rpc/pairs_cache.py
+++ b/avantis_trader_sdk/rpc/pairs_cache.py
@@ -1,4 +1,5 @@
 from ..types import PairInfoWithData
+from ..utils import encode_abi
 
 
 class PairsCache:
@@ -35,11 +36,9 @@ class PairsCache:
 
             calls = []
             for pair_index in range(pairs_count):
-                core_call_data = PairStorage.encodeABI(
-                    fn_name="pairs", args=[pair_index]
-                )
-                pair_data_call_data = PairStorage.encodeABI(
-                    fn_name="getPairData", args=[pair_index]
+                core_call_data = encode_abi(PairStorage, "pairs", args=[pair_index])
+                pair_data_call_data = encode_abi(
+                    PairStorage, "getPairData", args=[pair_index]
                 )
                 calls.extend(
                     [

--- a/avantis_trader_sdk/utils.py
+++ b/avantis_trader_sdk/utils.py
@@ -1,4 +1,4 @@
-from web3 import Web3
+from web3 import Web3, __version__ as web3_version
 
 
 def is_tuple_type(type_):
@@ -76,3 +76,12 @@ def decoder(web3, contract, function_name, raw_output):
         decoded_output = web3.codec.decode(output_types, raw_output)
     decoded_output = assign_names_to_decoded(decoded_output, abi_outputs)
     return decoded_output
+
+
+def encode_abi(contract, abi_element_identifier, args=None, kwargs=None, data=None):
+    """Allow compatibility with multiple major versions of web3
+    """
+    if int(web3_version.split('.')[0]) >= 7:
+        return contract.encode_abi(abi_element_identifier, args=args, kwargs=kwargs, data=data)
+    else:
+        return contract.encodeABI(fn_name=abi_element_identifier, args=args, kwargs=kwargs, data=data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-web3>=6.15.1,<7
+web3>=6.15.1,<8
 pydantic>=2.8.2,<3
 websockets>=12.0,<14
 boto3>=1.35.44,<2
-eth_account>=0.10.0,<0.12.0
+eth_account>=0.10.0,<0.14.0
 toolz>=0.12.1,<1
 eth_utils>=2.1.0,<5
 pyasn1>=0.6.1,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ websockets>=12.0,<14
 boto3>=1.35.44,<2
 eth_account>=0.10.0,<0.14.0
 toolz>=0.12.1,<1
-eth_utils>=2.1.0,<5
+eth_utils>=2.1.0,<6
 pyasn1>=0.6.1,<1

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(
     url="https://avantisfi.com/",
     packages=find_packages(),
     install_requires=[
-        "web3>=6.15.1,<7",
+        "web3>=6.15.1,<8",
         "pydantic>=2.8.2,<3",
         "websockets>=12.0,<14",
         "boto3>=1.35.44,<2",
-        "eth_account>=0.10.0,<0.12.0",
+        "eth_account>=0.10.0,<0.14.0",
         "toolz>=0.12.1,<1",
         "eth_utils>=2.1.0,<5",
         "pyasn1>=0.6.1,<1",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "boto3>=1.35.44,<2",
         "eth_account>=0.10.0,<0.14.0",
         "toolz>=0.12.1,<1",
-        "eth_utils>=2.1.0,<5",
+        "eth_utils>=2.1.0,<6",
         "pyasn1>=0.6.1,<1",
     ],
     classifiers=[


### PR DESCRIPTION
Web3 library version 7 introduces [many backward-breaking changes](https://web3py.readthedocs.io/en/stable/migration.html#migrating-from-v6-to-v7). This affects the use of encodeABI method by this SDK. This PR addresses it by adding a utils function that works with both web3 v6 and v7. Also a few other dependencies are loosened as the library seems to work with those versions as well.