### PR TITLE
Fix missing self reference in get_latest_price_updates call

### DIFF
--- a/avantis_trader_sdk/rpc/trade.py
+++ b/avantis_trader_sdk/rpc/trade.py
@@ -609,7 +609,7 @@ class TradeRPC:
 
         pair_name = await self.client.pairs_cache.get_pair_name_from_index(pair_index)
 
-        price_data = await feed_client.get_latest_price_updates([pair_name])
+        price_data = await self.feed_client.get_latest_price_updates([pair_name])
 
         price_update_data = "0x" + price_data.binary.data[0]
 


### PR DESCRIPTION
self reference was missing, build_trade_tp_sl_update_tx() function raises undefined feed_client error. 