### PR TITLE
fix: remove erroneous self.FeedClient() call in build_trade_tp_sl_update_tx_delegate

### DIFF
--- a/avantis_trader_sdk/rpc/trade.py
+++ b/avantis_trader_sdk/rpc/trade.py
@@ -666,7 +666,6 @@ class TradeRPC:
         if trader is None:
             trader = self.client.get_signer().get_ethereum_address()
 
-        feed_client = self.FeedClient()
 
         pair_name = await self.client.pairs_cache.get_pair_name_from_index(pair_index)
 


### PR DESCRIPTION
### Summary

Fixes `AttributeError: 'TradeRPC' object has no attribute 'FeedClient'` when calling `build_trade_tp_sl_update_tx_delegate()`.

### Problem

In `avantis_trader_sdk/rpc/trade.py`, line 669 contains:

```python
feed_client = self.FeedClient()
```

This causes an `AttributeError` because `TradeRPC` class has no attribute named `FeedClient`.

#### What exists in the class:

| Reference | Type | Exists? |
|-----------|------|---------|
| `FeedClient` | Module-level import (class) | ✅ |
| `self.feed_client` | Instance attribute (set in constructor) | ✅ |
| `self.FeedClient` | Attribute on TradeRPC | ❌ Does not exist |

#### Additionally:

The variable `feed_client` created on line 669 is **never used**. Line 673 correctly uses the existing `self.feed_client`:

```python
price_data = await self.feed_client.get_latest_price_updates([pair_name])
```

### Error Message

```
AttributeError: 'TradeRPC' object has no attribute 'FeedClient'
```

### Solution

Remove line 669 entirely, as it is both incorrect and unused.

### Testing

- SDK version: 0.8.12
- Python version: 3.11
- Confirmed `build_trade_tp_sl_update_tx_delegate()` works correctly after removing the line

### Affected Method

- `TradeRPC.build_trade_tp_sl_update_tx_delegate()` in `avantis_trader_sdk/rpc/trade.py`
